### PR TITLE
Xlsx reporter

### DIFF
--- a/framework/gulp/tasks.js
+++ b/framework/gulp/tasks.js
@@ -67,6 +67,7 @@ module.exports = function (gulp, envs, credentialManagerClass = CredentialManage
         const metadata = Object.assign(require(path.resolve("./test/metadata.json")), require(path.resolve("./protractor.conf.js")).config.capabilities.metadata);
         Reporter.generateHTMLReport(metadata);
         Reporter.generateXMLReport("./test/report.json", "./test/report.xml");
+        Reporter.generateXLSXReport("./test/report.json", "./test/report.xlsx");
     });
 
     gulp.task("c_server", () => {

--- a/framework/reporter/Reporter.js
+++ b/framework/reporter/Reporter.js
@@ -110,7 +110,7 @@ class Reporter {
                 return data;
             });
 
-            xlsxReporter.createSheet(dataResult, outputPathXlsx);
+            xlsxReporter.createSheets(dataResult, outputPathXlsx);
         })
     }
 

--- a/framework/reporter/Reporter.js
+++ b/framework/reporter/Reporter.js
@@ -4,6 +4,8 @@ const report = require("multiple-cucumber-html-reporter");
 const xml2js = require("xml2js");
 const JunitReport = require("./JunitReport");
 const os = require("os");
+const XlsxReporter = require("./XlsxReporter");
+const xlsxReporter = new XlsxReporter();
 
 /**
  * Reporter
@@ -78,6 +80,38 @@ class Reporter {
                 if (err) throw err
             })
         });
+    }
+
+    /**
+     * Generate xlsx report
+     * @param {string} pathToJson
+     * @param {string} outputPathXlsx
+     */
+    static generateXLSXReport(pathToJson, outputPathXlsx) {
+
+        this.glueReports(pathToJson, jsonReport => {
+
+            const dataResult = JSON.parse(jsonReport).map(json => {
+
+                const data = {
+                    "feature": "",
+                    "name": "",
+                    "tags": "",
+                    "status": "passed"
+                };
+
+                data.feature = json.name;
+                json.elements.map(e => {
+                    data.name = e.name;
+                    data.tags = e.tags.map(t => t.name).slice(0, -1).join(", ");
+                    data.status = e.steps.some(s => s.result.status === "failed") ? "failed" : data.status
+                });
+
+                return data;
+            });
+
+            xlsxReporter.createSheet(dataResult, outputPathXlsx);
+        })
     }
 
     /**

--- a/framework/reporter/XlsxReporter.js
+++ b/framework/reporter/XlsxReporter.js
@@ -1,0 +1,46 @@
+const xlsx = require("xlsx-populate");
+
+class XlsxReporter {
+
+    createSheet(data, outputPathXlsx) {
+
+        xlsx.fromBlankAsync().then(workbook => {
+
+            const FEATURE = "A";
+            const NAME = "B";
+            const TAGS = "C";
+            const STATUS = "D";
+            const blueBackgroundColor = "44a3ef";
+            const redBackgroundColor = "ff7d79";
+            const greenBackgroundColor = "65c7a3";
+
+            const sheet = workbook.addSheet("all_report");
+
+            sheet.column(FEATURE).style({border: true});
+            sheet.column(NAME).width(60).style({border: true});
+            sheet.column(TAGS).width(30).style({border: true});
+            sheet.column(STATUS).style({border: true});
+
+            sheet.cell(FEATURE + 1).value("Feature").style({fill: blueBackgroundColor, bold: true});
+            sheet.cell(NAME + 1).value("Name").style({fill: blueBackgroundColor, bold: true});
+            sheet.cell(TAGS + 1).value("Tags").style({fill: blueBackgroundColor, bold: true});
+            sheet.cell(STATUS + 1).value("Status").style({fill: blueBackgroundColor, bold: true});
+
+            workbook.deleteSheet("Sheet1");
+
+            data.forEach((element, i) => {
+                const currI = i + 2;
+                const statusColor = element.status === "failed" ? redBackgroundColor : greenBackgroundColor;
+
+                sheet.cell(FEATURE + currI).value(element.feature);
+                sheet.cell(NAME + currI).value(element.name);
+                sheet.cell(TAGS + currI).value(element.tags);
+                sheet.cell(STATUS + currI).style("fill", statusColor).value(element.status);
+            });
+
+            return workbook.toFileAsync(outputPathXlsx);
+        })
+    }
+}
+
+module.exports = XlsxReporter;

--- a/framework/reporter/XlsxReporter.js
+++ b/framework/reporter/XlsxReporter.js
@@ -2,7 +2,7 @@ const xlsx = require("xlsx-populate");
 
 class XlsxReporter {
 
-    createSheet(data, outputPathXlsx) {
+    createSheets(data, outputPathXlsx) {
 
         xlsx.fromBlankAsync().then(workbook => {
 
@@ -10,33 +10,74 @@ class XlsxReporter {
             const NAME = "B";
             const TAGS = "C";
             const STATUS = "D";
+            const PASSED = "J";
+            const FAILED = "K";
+
             const blueBackgroundColor = "44a3ef";
             const redBackgroundColor = "ff7d79";
             const greenBackgroundColor = "65c7a3";
 
-            const sheet = workbook.addSheet("all_report");
+            const sheetNames = ["all_report", "failed_tests", "passed_tests"];
 
-            sheet.column(FEATURE).style({border: true});
-            sheet.column(NAME).width(60).style({border: true});
-            sheet.column(TAGS).width(30).style({border: true});
-            sheet.column(STATUS).style({border: true});
+            sheetNames.forEach(name => {
 
-            sheet.cell(FEATURE + 1).value("Feature").style({fill: blueBackgroundColor, bold: true});
-            sheet.cell(NAME + 1).value("Name").style({fill: blueBackgroundColor, bold: true});
-            sheet.cell(TAGS + 1).value("Tags").style({fill: blueBackgroundColor, bold: true});
-            sheet.cell(STATUS + 1).value("Status").style({fill: blueBackgroundColor, bold: true});
+                const sheet = workbook.addSheet(name);
 
-            workbook.deleteSheet("Sheet1");
+                sheet.column(FEATURE).style({border: true});
+                sheet.column(NAME).width(60).style({border: true});
+                sheet.column(TAGS).width(30).style({border: true});
+                sheet.column(STATUS).style({border: true});
+
+                sheet.cell(FEATURE + 1).value("Feature").style({fill: blueBackgroundColor, bold: true});
+                sheet.cell(NAME + 1).value("Name").style({fill: blueBackgroundColor, bold: true});
+                sheet.cell(TAGS + 1).value("Tags").style({fill: blueBackgroundColor, bold: true});
+                sheet.cell(STATUS + 1).value("Status").style({fill: blueBackgroundColor, bold: true});
+
+                if (name === "all_report") {
+                    sheet.cell(PASSED + 10).value("Passed").style({fill: greenBackgroundColor, bold: true, border: true});
+                    sheet.cell(FAILED + 10).value("Failed").style({fill: redBackgroundColor, bold: true, border: true});
+
+                    sheet.cell(PASSED + 11).value(data.filter(d => d.status === "passed").length.toString())
+                        .style({bold: true, border: true});
+                    sheet.cell(FAILED + 11).value(data.filter(d => d.status === "failed").length.toString())
+                        .style({bold: true, border: true});
+
+                }
+            });
+
+            const allSheet = workbook.sheet("all_report");
+            const failedSheet = workbook.sheet("failed_tests");
+            const passedSheet = workbook.sheet("passed_tests");
 
             data.forEach((element, i) => {
                 const currI = i + 2;
                 const statusColor = element.status === "failed" ? redBackgroundColor : greenBackgroundColor;
 
-                sheet.cell(FEATURE + currI).value(element.feature);
-                sheet.cell(NAME + currI).value(element.name);
-                sheet.cell(TAGS + currI).value(element.tags);
-                sheet.cell(STATUS + currI).style("fill", statusColor).value(element.status);
+                allSheet.cell(FEATURE + currI).value(element.feature);
+                allSheet.cell(NAME + currI).value(element.name);
+                allSheet.cell(TAGS + currI).value(element.tags);
+                allSheet.cell(STATUS + currI).style("fill", statusColor).value(element.status);
             });
+
+            data.filter(e => e.status === "failed").forEach((element, i) => {
+                const currI = i + 2;
+
+                failedSheet.cell(FEATURE + currI).value(element.feature);
+                failedSheet.cell(NAME + currI).value(element.name);
+                failedSheet.cell(TAGS + currI).value(element.tags);
+                failedSheet.cell(STATUS + currI).style("fill", redBackgroundColor).value(element.status);
+            });
+
+            data.filter(e => e.status !== "failed").forEach((element, i) => {
+                const currI = i + 2;
+
+                passedSheet.cell(FEATURE + currI).value(element.feature);
+                passedSheet.cell(NAME + currI).value(element.name);
+                passedSheet.cell(TAGS + currI).value(element.tags);
+                passedSheet.cell(STATUS + currI).style("fill", greenBackgroundColor).value(element.status);
+            });
+
+            workbook.deleteSheet("Sheet1");
 
             return workbook.toFileAsync(outputPathXlsx);
         })

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "protractor-cucumber-framework": "^4.2.0",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
+    "xlsx-populate": "^1.17.0",
     "xml2js": "^0.4.19",
     "yargs": "^11.0.0"
   },


### PR DESCRIPTION

Add xlsx report based on xlsx-populate lib. 
- Extend gulp.task "report" to make xlsx report. 
- Add one class XlsxReporter with createSheets method which let create a template for reporter.
- GenerateXLSXReport method in Reporter class make a data which need for report template and transmit its to createSheets method from XlsxReporter class.
- Create 3 sheets, one of them for whole tests, another one with failed tests and another one for passed.
- Add counters on all test sheet by passed and failed tests.